### PR TITLE
remove suite roll up attributes

### DIFF
--- a/python_testspace_xml/testspace_xml.py
+++ b/python_testspace_xml/testspace_xml.py
@@ -206,10 +206,6 @@ class TestSuite:
         self.is_root_suite = False
         self.name = name
         self.description = ''
-        self.passed = 0
-        self.failed = 0
-        self.not_applicable = 0
-        self.in_progress = 0
         self.start_time = ''
         self.test_cases = []
         self.custom_data = []
@@ -224,21 +220,8 @@ class TestSuite:
             a.clean_up()
 
     def add_test_case(self, tc):
-        self.update_roll_ups(tc)
         self.test_cases.append(tc)
         return tc
-
-    def update_roll_ups(self, tc):
-        if tc.status == 'passed':
-            self.passed += 1
-        elif tc.status == 'failed':
-            self.failed += 1
-        elif tc.status == 'not_applicable':
-            self.not_applicable += 1
-        elif tc.status == 'in_progress':
-            self.in_progress += 1
-        elif True:
-            assert (False)
 
     def get_or_add_suite(self, suite_name):
         if not suite_name:
@@ -311,10 +294,6 @@ class XmlWriter:
             suite_elem = self.dom.createElement('test_suite')
             suite_elem.setAttribute('name', test_suite.name)
             suite_elem.setAttribute('description', test_suite.description)
-            suite_elem.setAttribute('passed', str(test_suite.passed))
-            suite_elem.setAttribute('failed', str(test_suite.failed))
-            suite_elem.setAttribute('not_applicable', str(test_suite.not_applicable))
-            suite_elem.setAttribute('in_progress', str(test_suite.in_progress))
             suite_elem.setAttribute('start_time', str(test_suite.start_time))
             parent_node.appendChild(suite_elem)
 

--- a/tests/test_TestspaceReport.py
+++ b/tests/test_TestspaceReport.py
@@ -8,7 +8,11 @@ from lxml.etree import XMLSyntaxError
 def create_simple_testspace_xml(self):
     testspace_report = testspace_xml.TestspaceReport()
     example_suite = testspace_report.get_or_add_suite('Example Suite')
-    test_case = testspace_xml.TestCase('test a', 'passed')
+    test_case = testspace_xml.TestCase('passing case 1', 'passed')
+    example_suite.add_test_case(test_case)
+    test_case = testspace_xml.TestCase('passing case 2', 'passed')
+    example_suite.add_test_case(test_case)
+    test_case = testspace_xml.TestCase('failing case 1', 'failed')
     example_suite.add_test_case(test_case)
     testspace_report.xml_file('testspace.xml')
 
@@ -16,6 +20,7 @@ def create_simple_testspace_xml(self):
     self.testspace_xml_string = xml_file.read()
     xml_file.close()
 
+    self.testspace_xml_root = etree.fromstring(self.testspace_xml_string)
 
 class TestTestspaceXml:
     @pytest.fixture(autouse=True)
@@ -30,7 +35,16 @@ class TestTestspaceXml:
         os.remove('testspace.xml')
 
     def test_number_testcases(self):
-        assert 'passed="1"' in self.testspace_xml_string
+        test_cases = self.testspace_xml_root.xpath("//test_suite/test_case")
+        assert len(test_cases) is 3
+
+    def test_number_passed_testcases(self):
+        test_cases = self.testspace_xml_root.xpath("//test_suite/test_case[@status='passed']")
+        assert len(test_cases) is 2
+
+    def test_number_failed_testcases(self):
+        test_cases = self.testspace_xml_root.xpath("//test_suite/test_case[@status='failed']")
+        assert len(test_cases) is 1
 
     def test_validate_xsd(self):
         assert xml_validator(self.testspace_xml_string, 'tests/report_v1.xsd')


### PR DESCRIPTION
Based on this comment in [help](https://help.testspace.com/reference:result-file-format) and therefore the attributes for them were removed.
`These attributes are roll-up values calculated by Testspace and will be seen in exported report data. They are not required in XML that is uploaded. If given, these attributes will be ignored by Testspace.`