### PR TITLE
Remove illegal characters from xml

### DIFF
--- a/python_testspace_xml/testspace_xml.py
+++ b/python_testspace_xml/testspace_xml.py
@@ -11,14 +11,6 @@ import sys
 from xml.dom.minidom import parseString
 
 
-# try:
-#     # Python 2
-#     unichr
-# except NameError:  # pragma: nocover
-#     # Python 3
-#     unichr = chr
-
-
 class CustomData:
     def __init__(self, name, value):
         self.name = name

--- a/python_testspace_xml/testspace_xml.py
+++ b/python_testspace_xml/testspace_xml.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+import six
 import base64
 import gzip
 import os
@@ -9,8 +10,6 @@ import re
 import sys
 from xml.dom.minidom import parseString
 
-import builtins
-from six import u
 
 try:
     # Python 2
@@ -18,6 +17,7 @@ try:
 except NameError:  # pragma: nocover
     # Python 3
     unichr = chr
+
 
 class CustomData:
     def __init__(self, name, value):
@@ -340,7 +340,7 @@ class XmlWriter:
 
     @staticmethod
     def _invalid_xml_remove(string_to_clean):
-        #http://stackoverflow.com/questions/1707890/fast-way-to-filter-illegal-xml-unicode-chars-in-python
+        # http://stackoverflow.com/questions/1707890/fast-way-to-filter-illegal-xml-unicode-chars-in-python
         illegal_unichrs = [
             (0x00, 0x08), (0x0B, 0x1F), (0x7F, 0x84), (0x86, 0x9F),
             (0xD800, 0xDFFF), (0xFDD0, 0xFDDF), (0xFFFE, 0xFFFF),
@@ -355,9 +355,8 @@ class XmlWriter:
                           for (low, high) in illegal_unichrs
                           if low < sys.maxunicode]
 
-        illegal_xml_re = re.compile(u('[%s]') % u('').join(illegal_ranges))
+        illegal_xml_re = re.compile(six.u('[%s]') % six.u('').join(illegal_ranges))
         return illegal_xml_re.sub('', string_to_clean)
-
 
 
 class TestspaceReport(TestSuite):

--- a/python_testspace_xml/testspace_xml.py
+++ b/python_testspace_xml/testspace_xml.py
@@ -18,7 +18,7 @@ class CustomData:
 
     def write_xml(self, parent_element, dom):
         d_elem = dom.createElement('custom_data')
-        d_elem.setAttribute('name', self.name)
+        d_elem.setAttribute('name', XmlWriter.invalid_xml_remove(self.name))
         cdata = dom.createCDATASection(self.value)
         d_elem.appendChild(cdata)
         parent_element.appendChild(d_elem)
@@ -80,9 +80,9 @@ class Annotation:
 
     def write_xml(self, parent_element, dom):
         annotation = dom.createElement("annotation")
-        annotation.setAttribute("description", self.description)
+        annotation.setAttribute("description", XmlWriter.invalid_xml_remove(self.description))
         annotation.setAttribute("level", self.level)
-        annotation.setAttribute("name", self.name)
+        annotation.setAttribute("name", XmlWriter.invalid_xml_remove(self.name))
 
         if self.file_path is not None:
             if self.link_file:
@@ -102,7 +102,7 @@ class Annotation:
         # add comments
         for comment in self.comments:
             c_elem = dom.createElement("comment")
-            c_elem.setAttribute("label", comment.name)
+            c_elem.setAttribute("label", XmlWriter.invalid_xml_remove(comment.name))
             cdata = dom.createCDATASection(comment.comment)
             c_elem.appendChild(cdata)
             annotation.appendChild(c_elem)
@@ -279,9 +279,9 @@ class XmlWriter:
         if target_file_path:
             with open(target_file_path, 'w') as target_file:
                 if to_pretty:
-                    target_file.write(XmlWriter._invalid_xml_remove(self.dom.toprettyxml()))
+                    target_file.write(self.dom.toprettyxml())
                 else:
-                    target_file.write(XmlWriter._invalid_xml_remove(self.dom.toxml()))
+                    target_file.write(self.dom.toxml())
                     target_file.flush()
         else:
             if to_pretty:
@@ -294,8 +294,8 @@ class XmlWriter:
         suite_elem = parent_node
         if not test_suite.is_root_suite:
             suite_elem = self.dom.createElement('test_suite')
-            suite_elem.setAttribute('name', test_suite.name)
-            suite_elem.setAttribute('description', test_suite.description)
+            suite_elem.setAttribute('name', XmlWriter.invalid_xml_remove(test_suite.name))
+            suite_elem.setAttribute('description', XmlWriter.invalid_xml_remove(test_suite.description))
             suite_elem.setAttribute('start_time', str(test_suite.start_time))
             parent_node.appendChild(suite_elem)
             if test_suite.duration > 0:
@@ -317,8 +317,8 @@ class XmlWriter:
     def _write_test_case(self, parent_node, test_case):
         elem_tc = self.dom.createElement('test_case')
 
-        elem_tc.setAttribute('name', test_case.name)
-        elem_tc.setAttribute('description', test_case.description)
+        elem_tc.setAttribute('name', XmlWriter.invalid_xml_remove(test_case.name))
+        elem_tc.setAttribute('description', XmlWriter.invalid_xml_remove(test_case.description))
         elem_tc.setAttribute('status', test_case.status)
         elem_tc.setAttribute('start_time', test_case.start_time)
         elem_tc.setAttribute('duration', str(test_case.duration))
@@ -331,7 +331,7 @@ class XmlWriter:
             d.write_xml(elem_tc, self.dom)
 
     @staticmethod
-    def _invalid_xml_remove(string_to_clean):
+    def invalid_xml_remove(string_to_clean):
         # http://stackoverflow.com/questions/1707890/fast-way-to-filter-illegal-xml-unicode-chars-in-python
         illegal_unichrs = [
             (0x00, 0x08), (0x0B, 0x1F), (0x7F, 0x84), (0x86, 0x9F),

--- a/python_testspace_xml/testspace_xml.py
+++ b/python_testspace_xml/testspace_xml.py
@@ -11,12 +11,12 @@ import sys
 from xml.dom.minidom import parseString
 
 
-try:
-    # Python 2
-    unichr
-except NameError:  # pragma: nocover
-    # Python 3
-    unichr = chr
+# try:
+#     # Python 2
+#     unichr
+# except NameError:  # pragma: nocover
+#     # Python 3
+#     unichr = chr
 
 
 class CustomData:
@@ -351,7 +351,7 @@ class XmlWriter:
             (0xDFFFE, 0xDFFFF), (0xEFFFE, 0xEFFFF), (0xFFFFE, 0xFFFFF),
             (0x10FFFE, 0x10FFFF)]
 
-        illegal_ranges = ["%s-%s" % (unichr(low), unichr(high))
+        illegal_ranges = ["%s-%s" % (six.unichr(low), six.unichr(high))
                           for (low, high) in illegal_unichrs
                           if low < sys.maxunicode]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ lxml
 flake8
 pep8-naming
 pytest-cov
+six

--- a/setup.py
+++ b/setup.py
@@ -15,5 +15,6 @@ setup(
         'pytest-cov',
         'flake8',
         'pep8-naming',
+        'six'
     ]
 )

--- a/tests/test_testspace_report_xsd.py
+++ b/tests/test_testspace_report_xsd.py
@@ -74,6 +74,10 @@ class TestTestspaceReportXsd:
         test_case.set_status('not_applicable')
         example_suite.add_test_case(test_case)
 
+        test_suite1 = testspace_report.get_or_add_test_suite('1 testsuite')
+        test_case = testspace_xml.TestCase('Test case with illegel xml characters & and \0x10FFFF')
+        test_suite1.add_test_case(test_case)
+
         testspace_report.write_xml('testspace.xml', to_pretty=True)
 
         xml_file = open('testspace.xml', 'r')
@@ -87,7 +91,7 @@ class TestTestspaceReportXsd:
         """ teardown any state that was previously setup with a call to
         setup_class.
         """
-        os.remove('testspace.xml')
+        #os.remove('testspace.xml')
 
     def test_number_testsuites(self):
         test_suites = self.testspace_xml_root.xpath("//test_suite")
@@ -108,11 +112,15 @@ class TestTestspaceReportXsd:
 
     def test_number_testcases(self):
         test_cases = self.testspace_xml_root.xpath("//test_suite/test_case")
+        assert len(test_cases) is 5
+
+    def test_number_testcases_example_suite(self):
+        test_cases = self.testspace_xml_root.xpath("//test_suite[@name='Example Suite']/test_case")
         assert len(test_cases) is 4
 
     def test_number_passed_testcases(self):
         test_cases = self.testspace_xml_root.xpath("//test_suite/test_case[@status='passed']")
-        assert len(test_cases) is 2
+        assert len(test_cases) is 3
 
     def test_number_failed_testcases(self):
         test_cases = self.testspace_xml_root.xpath("//test_suite/test_case[@status='failed']")

--- a/tests/test_testspace_report_xsd.py
+++ b/tests/test_testspace_report_xsd.py
@@ -91,7 +91,7 @@ class TestTestspaceReportXsd:
         """ teardown any state that was previously setup with a call to
         setup_class.
         """
-        #os.remove('testspace.xml')
+        os.remove('testspace.xml')
 
     def test_number_testsuites(self):
         test_suites = self.testspace_xml_root.xpath("//test_suite")


### PR DESCRIPTION
The added code seems to be pretty widely used to remove at least some of illegal characters that can be seen. For & < > the xml library handles directly. 